### PR TITLE
Switched POI APIs to SXSSF (Streaming XSSF)

### DIFF
--- a/src/main/groovy/com/jameskleeh/excel/CellFinder.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/CellFinder.groovy
@@ -20,7 +20,7 @@ package com.jameskleeh.excel
 
 import groovy.transform.CompileStatic
 import org.apache.poi.ss.util.CellReference
-import org.apache.poi.xssf.usermodel.XSSFCell
+import org.apache.poi.xssf.streaming.SXSSFCell
 
 /**
  * A class to get references to cells for use in other functions
@@ -31,10 +31,10 @@ import org.apache.poi.xssf.usermodel.XSSFCell
 @CompileStatic
 class CellFinder {
 
-    private final XSSFCell cell
+    private final SXSSFCell cell
     private final Map<Object, Integer> columnIndexes
 
-    CellFinder(XSSFCell cell, Map<Object, Integer> columnIndexes) {
+    CellFinder(SXSSFCell cell, Map<Object, Integer> columnIndexes) {
         this.cell = cell
         this.columnIndexes = columnIndexes
     }

--- a/src/main/groovy/com/jameskleeh/excel/CellStyleBuilder.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/CellStyleBuilder.groovy
@@ -28,12 +28,12 @@ import org.apache.poi.ss.usermodel.FillPatternType
 import org.apache.poi.ss.usermodel.Font as FontType
 import org.apache.poi.ss.usermodel.HorizontalAlignment
 import org.apache.poi.ss.usermodel.VerticalAlignment
-import org.apache.poi.xssf.usermodel.XSSFCell
+import org.apache.poi.xssf.streaming.SXSSFCell
 import org.apache.poi.xssf.usermodel.XSSFCellStyle
 import org.apache.poi.xssf.usermodel.XSSFColor
 import org.apache.poi.xssf.usermodel.XSSFFont
-import org.apache.poi.xssf.usermodel.XSSFRow
-import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.apache.poi.xssf.streaming.SXSSFRow
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
 import org.apache.poi.xssf.usermodel.extensions.XSSFCellBorder.BorderSide
 import java.awt.Color
 
@@ -46,9 +46,9 @@ import java.awt.Color
 @CompileStatic
 class CellStyleBuilder {
 
-    XSSFWorkbook workbook
+    SXSSFWorkbook workbook
 
-    private static final Map<XSSFWorkbook, WorkbookCache> WORKBOOK_CACHE = [:]
+    private static final Map<SXSSFWorkbook, WorkbookCache> WORKBOOK_CACHE = [:]
     protected static final String FORMAT = 'format'
     protected static final String HIDDEN = 'hidden'
     protected static final String LOCKED = 'locked'
@@ -76,7 +76,7 @@ class CellStyleBuilder {
     protected static final String BACKGROUND_COLOR = 'backgroundColor'
     protected static final String FOREGROUND_COLOR = 'foregroundColor'
 
-    CellStyleBuilder(XSSFWorkbook workbook) {
+    CellStyleBuilder(SXSSFWorkbook workbook) {
         this.workbook = workbook
         if (!WORKBOOK_CACHE.containsKey(workbook)) {
             WORKBOOK_CACHE.put(workbook, new WorkbookCache(workbook))
@@ -148,7 +148,7 @@ class CellStyleBuilder {
         WorkbookCache workbookCache = WORKBOOK_CACHE.get(workbook)
 
         if (!workbookCache.containsFont(fontOptions)) {
-            XSSFFont font = workbook.createFont()
+            XSSFFont font = (XSSFFont) workbook.createFont()
             if (fontOptions instanceof Map) {
                 Map fontMap = (Map)fontOptions
                 setBooleanFont(fontMap, FONT_BOLD, font.&setBold)
@@ -353,7 +353,7 @@ class CellStyleBuilder {
      * @return A cell style to apply
      */
      XSSFCellStyle buildStyle(Object value, Map options) {
-        XSSFCellStyle cellStyle = workbook.createCellStyle()
+        XSSFCellStyle cellStyle = (XSSFCellStyle) workbook.createCellStyle()
         if (options.containsKey(FORMAT)) {
             setFormat(cellStyle, options[FORMAT])
         }
@@ -428,7 +428,7 @@ class CellStyleBuilder {
      * @param _options A map of options for styling
      * @param defaultOptions A map of default options for styling
      */
-     void setStyle(Object value, XSSFCell cell, Map options, Map defaultOptions = null) {
+     void setStyle(Object value, SXSSFCell cell, Map options, Map defaultOptions = null) {
          XSSFCellStyle cellStyle = getStyle(value, options, defaultOptions)
          if (cellStyle != null) {
              cell.cellStyle = cellStyle
@@ -442,7 +442,7 @@ class CellStyleBuilder {
      * @param _options A map of options for styling
      * @param defaultOptions A map of default options for styling
      */
-    void setStyle(XSSFRow row, Map options, Map defaultOptions = null) {
+    void setStyle(SXSSFRow row, Map options, Map defaultOptions = null) {
         XSSFCellStyle cellStyle = getStyle(null, options, defaultOptions)
         if (cellStyle != null) {
             row.setRowStyle(cellStyle)
@@ -476,5 +476,5 @@ class CellStyleBuilder {
         setBorder(borderStyleApplier, border)
         borderStyleApplier.setStyles()
     }
-    
+
 }

--- a/src/main/groovy/com/jameskleeh/excel/Column.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/Column.groovy
@@ -23,9 +23,9 @@ import com.jameskleeh.excel.style.CellRangeBorderStyleApplier
 import com.jameskleeh.excel.style.ColumnCellRangeBorderStyleApplier
 import groovy.transform.CompileStatic
 import org.apache.poi.ss.util.CellRangeAddress
-import org.apache.poi.xssf.usermodel.XSSFCell
-import org.apache.poi.xssf.usermodel.XSSFRow
-import org.apache.poi.xssf.usermodel.XSSFSheet
+import org.apache.poi.xssf.streaming.SXSSFCell
+import org.apache.poi.xssf.streaming.SXSSFRow
+import org.apache.poi.xssf.streaming.SXSSFSheet
 import org.apache.poi.ss.usermodel.Row.MissingCellPolicy
 
 /**
@@ -40,19 +40,19 @@ class Column extends CreatesCells {
     private int columnIdx
     private int rowIdx
 
-    Column(XSSFSheet sheet, Map defaultOptions, Map<Object, Integer> columnIndexes, CellStyleBuilder styleBuilder, int columnIdx, int rowIdx) {
+    Column(SXSSFSheet sheet, Map defaultOptions, Map<Object, Integer> columnIndexes, CellStyleBuilder styleBuilder, int columnIdx, int rowIdx) {
         super(sheet, defaultOptions, columnIndexes, styleBuilder)
         this.columnIdx = columnIdx
         this.rowIdx = rowIdx
     }
 
     @Override
-    protected XSSFCell nextCell() {
-        XSSFRow row = sheet.getRow(rowIdx)
+    protected SXSSFCell nextCell() {
+        SXSSFRow row = sheet.getRow(rowIdx)
         if (row == null) {
             row = sheet.createRow(rowIdx)
         }
-        XSSFCell cell = row.getCell(columnIdx, MissingCellPolicy.CREATE_NULL_AS_BLANK)
+        SXSSFCell cell = row.getCell(columnIdx, MissingCellPolicy.CREATE_NULL_AS_BLANK)
         rowIdx++
         cell
     }
@@ -83,7 +83,7 @@ class Column extends CreatesCells {
     }
 
     @Override
-    protected CellRangeBorderStyleApplier getBorderStyleApplier(CellRangeAddress range, XSSFSheet sheet) {
+    protected CellRangeBorderStyleApplier getBorderStyleApplier(CellRangeAddress range, SXSSFSheet sheet) {
         new ColumnCellRangeBorderStyleApplier(range, sheet)
     }
 

--- a/src/main/groovy/com/jameskleeh/excel/ExcelBuilder.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/ExcelBuilder.groovy
@@ -19,7 +19,7 @@ under the License.
 package com.jameskleeh.excel
 
 import groovy.transform.CompileStatic
-import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
 
 /**
  * The main class used to start building an excel document
@@ -37,18 +37,20 @@ class ExcelBuilder {
      * @param callable The closure to build the document
      */
     static void output(OutputStream outputStream, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Workbook) Closure callable) {
-        XSSFWorkbook wb = build(callable)
+        SXSSFWorkbook wb = build(callable)
         wb.write(outputStream)
+        wb.dispose()
     }
 
     /**
      * Builds an excel document
      *
      * @param callable The closure to build the document
-     * @return The native workbook
+     * @return The native workbook, which MUST be disposed of using its dispose() method.
      */
-    static XSSFWorkbook build(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Workbook) Closure callable) {
-        XSSFWorkbook wb = new XSSFWorkbook()
+    static SXSSFWorkbook build(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Workbook) Closure callable) {
+        SXSSFWorkbook wb = new SXSSFWorkbook()
+        wb.compressTempFiles = true
         callable.resolveStrategy = Closure.DELEGATE_FIRST
         callable.delegate = new Workbook(wb)
         if (callable.maximumNumberOfParameters == 1) {

--- a/src/main/groovy/com/jameskleeh/excel/Row.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/Row.groovy
@@ -23,9 +23,9 @@ import com.jameskleeh.excel.style.CellRangeBorderStyleApplier
 import com.jameskleeh.excel.style.RowCellRangeBorderStyleApplier
 import groovy.transform.CompileStatic
 import org.apache.poi.ss.util.CellRangeAddress
-import org.apache.poi.xssf.usermodel.XSSFCell
-import org.apache.poi.xssf.usermodel.XSSFRow
-import org.apache.poi.xssf.usermodel.XSSFSheet
+import org.apache.poi.xssf.streaming.SXSSFCell
+import org.apache.poi.xssf.streaming.SXSSFRow
+import org.apache.poi.xssf.streaming.SXSSFSheet
 
 /**
  * A class used to create a row in an excel document
@@ -36,19 +36,19 @@ import org.apache.poi.xssf.usermodel.XSSFSheet
 @CompileStatic
 class Row extends CreatesCells {
 
-    private final XSSFRow row
+    private final SXSSFRow row
 
     private int cellIdx
 
-    Row(XSSFRow row, Map defaultOptions, Map<Object, Integer> columnIndexes, CellStyleBuilder styleBuilder) {
+    Row(SXSSFRow row, Map defaultOptions, Map<Object, Integer> columnIndexes, CellStyleBuilder styleBuilder) {
         super(row.sheet, defaultOptions, columnIndexes, styleBuilder)
         this.row = row
         this.cellIdx = 0
     }
 
     @Override
-    protected XSSFCell nextCell() {
-        XSSFCell cell = row.createCell(cellIdx)
+    protected SXSSFCell nextCell() {
+        SXSSFCell cell = row.createCell(cellIdx)
         cellIdx++
         cell
     }
@@ -93,7 +93,7 @@ class Row extends CreatesCells {
     }
 
     @Override
-    protected CellRangeBorderStyleApplier getBorderStyleApplier(CellRangeAddress range, XSSFSheet sheet) {
+    protected CellRangeBorderStyleApplier getBorderStyleApplier(CellRangeAddress range, SXSSFSheet sheet) {
         new RowCellRangeBorderStyleApplier(range, sheet)
     }
 

--- a/src/main/groovy/com/jameskleeh/excel/Sheet.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/Sheet.groovy
@@ -19,8 +19,8 @@ under the License.
 package com.jameskleeh.excel
 
 import groovy.transform.CompileStatic
-import org.apache.poi.xssf.usermodel.XSSFRow
-import org.apache.poi.xssf.usermodel.XSSFSheet
+import org.apache.poi.xssf.streaming.SXSSFRow
+import org.apache.poi.xssf.streaming.SXSSFSheet
 
 /**
  * A class used to create a sheet in an excel document
@@ -31,7 +31,7 @@ import org.apache.poi.xssf.usermodel.XSSFSheet
 @CompileStatic
 class Sheet {
 
-    private final XSSFSheet sheet
+    private final SXSSFSheet sheet
     private int rowIdx
     private int columnIdx
     private Map defaultOptions
@@ -41,7 +41,7 @@ class Sheet {
     private static final String HEIGHT = 'height'
     private static final String WIDTH = 'width'
 
-    Sheet(XSSFSheet sheet, CellStyleBuilder styleBuilder) {
+    Sheet(SXSSFSheet sheet, CellStyleBuilder styleBuilder) {
         this.sheet = sheet
         this.rowIdx = 0
         this.columnIdx = 0
@@ -141,7 +141,7 @@ class Sheet {
      *
      * @return The native row
      */
-    XSSFRow row() {
+    SXSSFRow row() {
         row([:], null)
     }
 
@@ -151,7 +151,7 @@ class Sheet {
      * @param cells A list of data to output as cells
      * @return The native row
      */
-    XSSFRow row(Object...cells) {
+    SXSSFRow row(Object...cells) {
         row {
             cells.each { val ->
                 cell(val)
@@ -165,7 +165,7 @@ class Sheet {
      * @param callable To build row data
      * @return The native row
      */
-    XSSFRow row(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Row) Closure callable) {
+    SXSSFRow row(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Row) Closure callable) {
         row([:], callable)
     }
 
@@ -176,8 +176,8 @@ class Sheet {
      * @param callable To build row data
      * @return The native row
      */
-    XSSFRow row(Map options, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Row) Closure callable) {
-        XSSFRow row = sheet.createRow(rowIdx)
+    SXSSFRow row(Map options, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Row) Closure callable) {
+        SXSSFRow row = sheet.createRow(rowIdx)
         if (options?.containsKey(HEIGHT)) {
             Object height = options[HEIGHT]
             if (height instanceof Short) {

--- a/src/main/groovy/com/jameskleeh/excel/Workbook.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/Workbook.groovy
@@ -20,8 +20,8 @@ package com.jameskleeh.excel
 
 import groovy.transform.CompileStatic
 import org.apache.poi.ss.util.WorkbookUtil
-import org.apache.poi.xssf.usermodel.XSSFSheet
-import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.apache.poi.xssf.streaming.SXSSFSheet
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
 
 /**
  * A class used to create a workbook in an excel document
@@ -32,13 +32,13 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook
 @CompileStatic
 class Workbook {
 
-    private final XSSFWorkbook wb
+    private final SXSSFWorkbook wb
     private final CellStyleBuilder styleBuilder
 
     private static final String WIDTH = 'width'
     private static final String HEIGHT = 'height'
 
-    Workbook(XSSFWorkbook wb) {
+    Workbook(SXSSFWorkbook wb) {
         this.wb = wb
         this.styleBuilder = new CellStyleBuilder(wb)
     }
@@ -51,7 +51,7 @@ class Workbook {
      * @param callable To build data
      * @return The native sheet object
      */
-    XSSFSheet sheet(String name, Map options, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
+    SXSSFSheet sheet(String name, Map options, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
         handleSheet(wb.createSheet(WorkbookUtil.createSafeSheetName(name)), options, callable)
     }
 
@@ -62,7 +62,7 @@ class Workbook {
      * @param callable To build data
      * @return The native sheet object
      */
-    XSSFSheet sheet(String name, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
+    SXSSFSheet sheet(String name, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
         sheet(name, [:], callable)
     }
 
@@ -72,7 +72,7 @@ class Workbook {
      * @param callable To build data
      * @return The native sheet object
      */
-    XSSFSheet sheet(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
+    SXSSFSheet sheet(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
         sheet([:], callable)
     }
 
@@ -83,11 +83,11 @@ class Workbook {
      * @param callable To build data
      * @return The native sheet object
      */
-    XSSFSheet sheet(Map options, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
+    SXSSFSheet sheet(Map options, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Sheet) Closure callable) {
         handleSheet(wb.createSheet(), options, callable)
     }
 
-    private XSSFSheet handleSheet(XSSFSheet sheet, Map options, Closure callable) {
+    private SXSSFSheet handleSheet(SXSSFSheet sheet, Map options, Closure callable) {
         callable.resolveStrategy = Closure.DELEGATE_FIRST
         if (options.containsKey(WIDTH)) {
             Object width = options[WIDTH]

--- a/src/main/groovy/com/jameskleeh/excel/WorkbookCache.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/WorkbookCache.groovy
@@ -21,7 +21,7 @@ package com.jameskleeh.excel
 import groovy.transform.CompileStatic
 import org.apache.poi.xssf.usermodel.XSSFCellStyle
 import org.apache.poi.xssf.usermodel.XSSFFont
-import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
 
 /**
  * A class used to store fonts and styles for reuse in workbooks
@@ -35,9 +35,9 @@ class WorkbookCache {
     final Map<Object, XSSFFont> fonts = [:]
     final Map<Object, XSSFCellStyle> styles = [:]
 
-    private final XSSFWorkbook workbook
+    private final SXSSFWorkbook workbook
 
-    WorkbookCache(XSSFWorkbook workbook) {
+    WorkbookCache(SXSSFWorkbook workbook) {
         this.workbook = workbook
     }
 

--- a/src/main/groovy/com/jameskleeh/excel/style/CellRangeBorderStyleApplier.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/style/CellRangeBorderStyleApplier.groovy
@@ -4,7 +4,7 @@ import org.apache.poi.ss.usermodel.Cell
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.util.CellUtil
 import org.apache.poi.xssf.usermodel.XSSFCellStyle
-import org.apache.poi.xssf.usermodel.XSSFSheet
+import org.apache.poi.xssf.streaming.SXSSFSheet
 import groovy.transform.CompileStatic
 import groovy.transform.TupleConstructor
 import org.apache.poi.ss.usermodel.BorderStyle
@@ -31,14 +31,14 @@ abstract class CellRangeBorderStyleApplier implements BorderStyleApplier {
     protected XSSFCellStyle middle
     protected XSSFCellStyle bottomRight
 
-    CellRangeBorderStyleApplier(CellRangeAddress range, XSSFSheet sheet) {
+    CellRangeBorderStyleApplier(CellRangeAddress range, SXSSFSheet sheet) {
         this.range = range
         this.sheet = sheet
-        leftTop = sheet.workbook.createCellStyle()
+        leftTop = (XSSFCellStyle) sheet.workbook.createCellStyle()
         if (range.numberOfCells > 2) {
-            middle = sheet.workbook.createCellStyle()
+            middle = (XSSFCellStyle) sheet.workbook.createCellStyle()
         }
-        bottomRight = sheet.workbook.createCellStyle()
+        bottomRight = (XSSFCellStyle) sheet.workbook.createCellStyle()
 
         Row row = CellUtil.getRow(range.firstRow, sheet)
         leftTop.cloneStyleFrom(CellUtil.getCell(row, range.firstColumn).cellStyle)


### PR DESCRIPTION
Here is a PR with the minimal code changes needed use SXSSF (see https://github.com/jameskleeh/groovy-excel-builder/issues/21)

It works well and indeed uses less memory than the XSSF version, as well as being able to produce larger files much faster.

I haven't built it nor tested it with the Gradle build system of this repository, because I can't get it to work for some reason. (In fact, Travis fails too.) But the code **builds and works well in my own project,** using the same dependencies you have in your build.gradle