### PR TITLE
#28 Fix workbook memory leaks in workbook cache

### DIFF
--- a/src/main/groovy/com/jameskleeh/excel/CellStyleBuilder.groovy
+++ b/src/main/groovy/com/jameskleeh/excel/CellStyleBuilder.groovy
@@ -46,9 +46,9 @@ import java.awt.Color
 @CompileStatic
 class CellStyleBuilder {
 
-    XSSFWorkbook workbook
+    private final XSSFWorkbook workbook
+    private final WorkbookCache workbookCache
 
-    private static final Map<XSSFWorkbook, WorkbookCache> WORKBOOK_CACHE = [:]
     protected static final String FORMAT = 'format'
     protected static final String HIDDEN = 'hidden'
     protected static final String LOCKED = 'locked'
@@ -78,9 +78,7 @@ class CellStyleBuilder {
 
     CellStyleBuilder(XSSFWorkbook workbook) {
         this.workbook = workbook
-        if (!WORKBOOK_CACHE.containsKey(workbook)) {
-            WORKBOOK_CACHE.put(workbook, new WorkbookCache(workbook))
-        }
+        workbookCache = new WorkbookCache(workbook)
     }
 
     private static void convertBorderOptions(Map options, String key) {
@@ -145,8 +143,6 @@ class CellStyleBuilder {
     }
 
     private void setFont(XSSFCellStyle cellStyle, Object fontOptions) {
-        WorkbookCache workbookCache = WORKBOOK_CACHE.get(workbook)
-
         if (!workbookCache.containsFont(fontOptions)) {
             XSSFFont font = workbook.createFont()
             if (fontOptions instanceof Map) {
@@ -407,7 +403,6 @@ class CellStyleBuilder {
             }
         }
         if (options) {
-            WorkbookCache workbookCache = WORKBOOK_CACHE.get(workbook)
             if (workbookCache.containsStyle(options)) {
                 workbookCache.getStyle(options)
             } else {

--- a/src/test/groovy/com/jameskleeh/excel/CellStyleBuilderSpec.groovy
+++ b/src/test/groovy/com/jameskleeh/excel/CellStyleBuilderSpec.groovy
@@ -565,8 +565,8 @@ class CellStyleBuilderSpec extends Specification {
         cellStyleBuilder.getStyle('', [hidden: true])
 
         then:
-        cellStyleBuilder.WORKBOOK_CACHE[workbook].containsStyle([hidden: true])
-        cellStyleBuilder.WORKBOOK_CACHE[workbook].styles.size() == 1
+        cellStyleBuilder.workbookCache.containsStyle([hidden: true])
+        cellStyleBuilder.workbookCache.styles.size() == 1
     }
 
     void "test setStyle cell no options"() {


### PR DESCRIPTION
#28 
- Changed workbook cache field from static to non-static
- Changed workbook cache from map to a simple field
- Fixed workbook cache field name to non-static fields naming convention
- Removed redundant logic for workbook cache in CellStyleBuilder constructor