### PR TITLE
Fix travis build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ repositories {
 
 dependencies {
     provided 'org.codehaus.groovy:groovy:2.5.8'
+    compileClasspath 'org.codehaus.groovy:groovy-templates:2.5.8'
     compile "org.apache.poi:poi-ooxml:4.1.0"
     codenarc 'org.codenarc:CodeNarc:1.4'
     testCompile 'org.codehaus.groovy:groovy-dateutil:2.5.8'


### PR DESCRIPTION
This dependency was in groovy-all . But if you don't want groovy-all , I added it manually . As I understand compileClasspath prevents it from loading to the lib's users